### PR TITLE
fix http status code issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,6 @@ module.exports = function (sails) {
             }
 
             const endTimer = stats.httpMetric.histogram.startTimer({
-              status_code: (req.res && req.res.statusCode) || res.statusCode || 0,
               method: req.method,
               path: url
             })
@@ -52,7 +51,9 @@ module.exports = function (sails) {
             res.once('finish', function onceFinish () {
               stats.throughputMetric.inc()
 
-              endTimer()
+              endTimer({
+                status_code: (req.res && req.res.statusCode) || res.statusCode || 0,
+              })
             })
           }
 


### PR DESCRIPTION
The HTTP status was being set as 200 initially and therefore was showing the same value even if the response status code was changed. Now it has been moved to the finish listener where it is set at the end in order to project correct HTTP status.